### PR TITLE
Message fixes

### DIFF
--- a/src/ai/missions/MiningMission.ts
+++ b/src/ai/missions/MiningMission.ts
@@ -333,6 +333,13 @@ export class MiningMission extends Mission {
 
     private placeContainer() {
 
+        if (this.room.controller.reservation &&
+            /* reserved and not mine */
+            this.room.controller.reservation.username != Game.structures[_.first(Object.keys(Game.structures))].owner.username) {
+            // console.log(`MINER: Unable to place container in ${this.operation.name}, hostile reserved room`);
+            return;
+        }
+
         let startingPosition: {pos: RoomPosition} = this.findMinerStorage();
         if (!startingPosition) {
             startingPosition = this.room.find(FIND_MY_SPAWNS)[0] as StructureSpawn;

--- a/src/ai/operations/ControllerOperation.ts
+++ b/src/ai/operations/ControllerOperation.ts
@@ -386,10 +386,13 @@ export abstract class ControllerOperation extends Operation {
         }
 
         let coord = coords[this.memory.repairIndices[structureType]++];
-        let position = helper.coordToPosition(coord, this.memory.centerPosition, this.memory.rotation);
-        let structure = position.lookForStructure(structureType);
-        if (structure) {
-            this.repairLayout(structure);
+        //FIXME this check is for a room with a failed layout
+        if (this.memory.centerPosition) {
+            let position = helper.coordToPosition(coord, this.memory.centerPosition, this.memory.rotation);
+            let structure = position.lookForStructure(structureType);
+            if (structure) {
+                this.repairLayout(structure);
+            }
         }
     }
 


### PR DESCRIPTION
two fixes here. one eliminates an exception when repairTower tries to handle a room with a failed layout. the other makes miners stop reporting they are placing a container in a room with a hostile reservation.